### PR TITLE
feat: create user-roles smart contract

### DIFF
--- a/backend/Clarinet.toml
+++ b/backend/Clarinet.toml
@@ -1,0 +1,21 @@
+[project]
+name = "backend"
+authors = []
+description = "Smart contracts for the campaign platform"
+telemetry = true
+requirements = []
+
+[contracts.campaign]
+path = "contracts/campaign.clar"
+depends_on = []
+
+[contracts.user-roles]
+path = "contracts/user-roles.clar"
+depends_on = []
+
+[repl]
+clarity_version = 2
+repl_file = "lib/repl-utils.clar"
+
+[testing]
+testing_lib = "lib/test-utils.clar"

--- a/backend/contracts/campaign.clar
+++ b/backend/contracts/campaign.clar
@@ -1,0 +1,181 @@
+;; comprehensive-campaign-contract.clar
+;;
+;; This contract manages brand campaigns and rewards users with a fungible token
+;; for social media mentions, designed to be updated by a trusted off-chain oracle.
+;;
+;; Features:
+;; - Fungible Token for reward points ("reward-points").
+;; - Brands can create campaigns and fund them with these tokens.
+;; - A trusted Oracle can award points to users for verified off-chain actions.
+;; - Users can claim their earned points.
+;; - Brands can manage their campaign budget and status.
+
+;; ---
+;; Constants & Errors
+;; ---
+(define-constant CONTRACT_OWNER tx-sender)
+(define-constant ORACLE_PRINCIPAL tx-sender) ;; Initially the deployer, can be changed.
+
+;; Error Codes
+(define-constant ERR_UNAUTHORIZED (err u101))
+(define-constant ERR_CAMPAIGN_NOT_FOUND (err u102))
+(define-constant ERR_CAMPAIGN_INACTIVE (err u103))
+(define-constant ERR_INSUFFICIENT_BUDGET (err u104))
+(define-constant ERR_NO_REWARDS_TO_CLAIM (err u105))
+(define-constant ERR_CAMPAIGN_ALREADY_EXISTS (err u106))
+
+
+;; ---
+;; Fungible Token for Rewards
+;; ---
+(define-fungible-token reward-points)
+
+
+;; ---
+;; Data Storage
+;; ---
+
+;; A counter for unique campaign IDs
+(define-data-var campaign-id-counter uint u0)
+
+;; A map to store campaign details
+;; Key: uint (campaign-id)
+;; Value: A tuple with campaign properties
+(define-map campaigns uint {
+  brand-owner: principal,
+  name: (string-ascii 64),
+  total-budget: uint,
+  reward-per-mention: uint,
+  is-active: bool
+})
+
+;; A map to store rewards earned by a user for a campaign before they are claimed.
+;; This acts as a pending balance.
+;; Key: A tuple of (uint, principal) -> (campaign-id, user-principal)
+;; Value: uint (amount of pending rewards)
+(define-map user-pending-rewards { campaign-id: uint, user: principal } uint)
+
+
+;; ---
+;; Administrative & Oracle Functions
+;; ---
+
+;; @desc Awards points to a user for a verified mention.
+;; @desc ONLY callable by the designated Oracle.
+;; @param campaign-id: The campaign to award for.
+;; @param user: The user who earned the reward.
+;; @returns (ok bool) or an error.
+(define-public (award-mention (campaign-id uint) (user principal))
+  (begin
+    (asserts! (is-eq tx-sender ORACLE_PRINCIPAL) ERR_UNAUTHORIZED)
+
+    (let
+      ((campaign (unwrap! (map-get? campaigns campaign-id) ERR_CAMPAIGN_NOT_FOUND))
+       (reward-amount (get reward-per-mention campaign))
+       (current-pending-rewards (get-user-rewards-for-campaign campaign-id user)))
+
+      (asserts! (get is-active campaign) ERR_CAMPAIGN_INACTIVE)
+      (asserts! (>= (get total-budget campaign) reward-amount) ERR_INSUFFICIENT_BUDGET)
+
+      ;; Update the campaign's budget
+      (map-set campaigns campaign-id
+        (merge campaign { total-budget: (- (get total-budget campaign) reward-amount) }))
+
+      ;; Update the user's pending rewards
+      (map-set user-pending-rewards { campaign-id: campaign-id, user: user }
+        (+ current-pending-rewards reward-amount))
+
+      (ok true)
+    )
+  )
+)
+
+
+;; ---
+;; Brand (Campaign Owner) Functions
+;; ---
+
+;; @desc Creates a new campaign.
+;; @param name: The name of the campaign.
+;; @param initial-budget: The total amount of reward-points to fund the campaign with.
+;; @param reward-per-mention: How many points to award for each mention.
+;; @returns (ok uint) with the new campaign ID, or an error.
+(define-public (create-campaign (name (string-ascii 64)) (initial-budget uint) (reward-per-mention uint))
+  (let ((new-id (+ (var-get campaign-id-counter) u1)))
+    ;; The brand must have enough reward-points to fund the campaign
+    (try! (ft-transfer? reward-points initial-budget tx-sender (as-contract tx-sender)))
+
+    (map-set campaigns new-id {
+      brand-owner: tx-sender,
+      name: name,
+      total-budget: initial-budget,
+      reward-per-mention: reward-per-mention,
+      is-active: true
+    })
+    (var-set campaign-id-counter new-id)
+    (ok new-id)
+  )
+)
+
+;; @desc Allows a brand to deactivate their campaign and reclaim the remaining budget.
+;; @param campaign-id: The ID of the campaign to deactivate.
+;; @returns (ok bool) or an error.
+(define-public (deactivate-campaign (campaign-id uint))
+  (let ((campaign (unwrap! (map-get? campaigns campaign-id) ERR_CAMPAIGN_NOT_FOUND)))
+    (asserts! (is-eq tx-sender (get brand-owner campaign)) ERR_UNAUTHORIZED)
+
+    ;; Reclaim remaining budget
+    (let ((remaining-budget (get total-budget campaign)))
+      (if (> remaining-budget u0)
+        (try! (as-contract (ft-transfer? reward-points remaining-budget (as-contract tx-sender) (get brand-owner campaign))))
+        true
+      )
+    )
+
+    (map-set campaigns campaign-id (merge campaign { is-active: false, total-budget: u0 }))
+    (ok true)
+  )
+)
+
+
+;; ---
+;; Participant (User) Functions
+;; ---
+
+;; @desc Allows a user to claim their pending rewards from a campaign.
+;; @param campaign-id: The campaign to claim rewards from.
+;; @returns (ok bool) or an error.
+(define-public (claim-rewards (campaign-id uint))
+  (let
+    ((rewards-to-claim (get-user-rewards-for-campaign campaign-id tx-sender)))
+    (asserts! (> rewards-to-claim u0) ERR_NO_REWARDS_TO_CLAIM)
+
+    ;; Reset pending rewards for this user and campaign to 0
+    (map-delete user-pending-rewards { campaign-id: campaign-id, user: tx-sender })
+
+    ;; Transfer the claimed tokens from the contract to the user
+    (try! (as-contract (ft-transfer? reward-points rewards-to-claim (as-contract tx-sender) tx-sender)))
+
+    (ok true)
+  )
+)
+
+
+;; ---
+;; Read-Only Functions
+;; ---
+
+;; @desc Get details for a specific campaign.
+(define-read-only (get-campaign-details (campaign-id uint))
+  (map-get? campaigns campaign-id)
+)
+
+;; @desc Get the pending (unclaimed) rewards for a user for a specific campaign.
+(define-read-only (get-user-rewards-for-campaign (campaign-id uint) (user principal))
+  (default-to u0 (map-get? user-pending-rewards { campaign-id: campaign-id, user: user }))
+)
+
+;; @desc Get the total number of campaigns created.
+(define-read-only (get-campaign-count)
+  (ok (var-get campaign-id-counter))
+)

--- a/backend/contracts/user-roles.clar
+++ b/backend/contracts/user-roles.clar
@@ -1,0 +1,56 @@
+;; user-roles.clar
+;;
+;; This contract serves as a central registry for user roles within the application.
+;; It allows an admin to assign roles ('admin', 'brand', 'participant') to user principals.
+;; Other contracts can then query this contract to check permissions.
+
+;; ---
+;; Constants and Errors
+;; ---
+(define-constant CONTRACT_OWNER tx-sender)
+(define-constant ERR_UNAUTHORIZED (err u201))
+(define-constant ERR_INVALID_ROLE (err u202))
+
+;; ---
+;; Data Storage
+;; ---
+
+;; A map to store the role for each user principal.
+;; key: principal
+;; value: (string-ascii 12) - e.g., "admin", "brand", "participant"
+(define-map roles principal (string-ascii 12))
+
+;; ---
+;; Public Functions
+;; ---
+
+;; @desc Assigns a role to a user.
+;; @desc Can only be called by the CONTRACT_OWNER (the initial admin).
+;; @param user: The principal of the user to assign a role to.
+;; @param role: The role to assign. Must be "admin", "brand", or "participant".
+;; @returns (ok bool) or an error.
+(define-public (set-role (user principal) (new-role (string-ascii 12)))
+  (begin
+    ;; Ensure only the contract owner can set roles
+    (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_UNAUTHORIZED)
+
+    ;; Ensure the role is one of the valid types
+    (asserts! (or (is-eq new-role "admin") (or (is-eq new-role "brand") (is-eq new-role "participant"))) ERR_INVALID_ROLE)
+
+    ;; Set the role in the map
+    (map-set roles user new-role)
+    (ok true)
+  )
+)
+
+
+;; ---
+;; Read-Only Functions
+;; ---
+
+;; @desc Retrieves the role for a given user.
+;; @param user: The principal of the user to check.
+;; @returns (response (string-ascii 12) "none") - The user's role, or "participant" if none is set.
+(define-read-only (get-role (user principal))
+  (ok (default-to "participant" (map-get? roles user)))
+)


### PR DESCRIPTION
This commit introduces a new contract, `user-roles.clar`, to manage on-chain permissions. This contract acts as a central registry for assigning and querying user roles (`admin`, `brand`, `participant`).

Key features include:
- A protected `set-role` function, callable only by the contract owner, to securely manage role assignments.
- A public `get-role` read-only function that allows other contracts and clients to easily check a user's permissions.

This modular design improves the application's security and separation of concerns, laying the groundwork for permissioned actions in the application.